### PR TITLE
Rebase to debian as Alpine chromium is currently not working inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:alpine318
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 # set version label
 ARG BUILD_DATE
@@ -11,10 +11,15 @@ ENV TITLE=Chromium
 
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     chromium && \
   echo "**** cleanup ****" && \
+  apt-get autoclean && \
   rm -rf \
+    /config/.cache \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
     /tmp/*
 
 # add local files

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-alpine318
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-debianbookworm
 
 # set version label
 ARG BUILD_DATE
@@ -11,10 +11,15 @@ ENV TITLE=Chromium
 
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
     chromium && \
   echo "**** cleanup ****" && \
+  apt-get autoclean && \
   rm -rf \
+    /config/.cache \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
     /tmp/*
 
 # add local files

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     DOCKERHUB_IMAGE = 'linuxserver/chromium'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/chromium'
     PR_DOCKERHUB_IMAGE = 'lspipepr/chromium'
-    DIST_IMAGE = 'alpine'
+    DIST_IMAGE = 'ubuntu'
     MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **13.05.23:** - Rebase to Debian Bookworm.
 * **13.05.23:** - Rebase to Alpine 3.18.
 * **01.04.23:** - Preserve arguments passed to Chromium and restructure to use wrapper.
 * **18.03.23:** - Initial release.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -15,7 +15,7 @@ repo_vars:
   - DOCKERHUB_IMAGE = 'linuxserver/chromium'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/chromium'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/chromium'
-  - DIST_IMAGE = 'alpine'
+  - DIST_IMAGE = 'ubuntu'
   - MULTIARCH = 'true'
   - CI = 'true'
   - CI_WEB = 'true'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -76,6 +76,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "13.05.23:", desc: "Rebase to Debian Bookworm." }
   - { date: "13.05.23:", desc: "Rebase to Alpine 3.18." }
   - { date: "01.04.23:", desc: "Preserve arguments passed to Chromium and restructure to use wrapper." }
   - { date: "18.03.23:", desc: "Initial release." }

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,2 +1,2 @@
 #!/bin/bash
-chromium-browser ${CHROME_CLI}
+wrapped-chromium ${CHROME_CLI}

--- a/root/usr/bin/wrapped-chromium
+++ b/root/usr/bin/wrapped-chromium
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BIN=/usr/lib/chromium/chromium-launcher.sh
+BIN=/usr/bin/chromium
 
 # Run normally on privved containers or modified un non priv
 if grep -q 'Seccomp:\t0' /proc/1/status; then


### PR DESCRIPTION
I actually went as far as getting Alpine running bare metal to ensure this is only a docker thing and it is, bare metal and VM Alpine runs Chromium fine. It looks like Alpine Chromium just doesn't work anymore specifically in our base, can go full priv unconfined apparmor and same result segfaults. 

Rebasing to debian was the only solution I could find. 