### PR TITLE
Launch fix #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **13.05.23:** - Rebase to Debian Bookworm.
+* **08.01.24:** - Fix re-launch issue for chromium by purging temp files on launch.
+* **29.12.23:** - Rebase to Debian Bookworm.
 * **13.05.23:** - Rebase to Alpine 3.18.
 * **01.04.23:** - Preserve arguments passed to Chromium and restructure to use wrapper.
 * **18.03.23:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -76,7 +76,8 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "13.05.23:", desc: "Rebase to Debian Bookworm." }
+  - { date: "08.01.24:", desc: "Fix re-launch issue for chromium by purging temp files on launch." }
+  - { date: "29.12.23:", desc: "Rebase to Debian Bookworm." }
   - { date: "13.05.23:", desc: "Rebase to Alpine 3.18." }
   - { date: "01.04.23:", desc: "Preserve arguments passed to Chromium and restructure to use wrapper." }
   - { date: "18.03.23:", desc: "Initial release." }

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
-<item label="Chromium" icon="/usr/share/icons/hicolor/48x48/apps/chromium.png"><action name="Execute"><command>/usr/bin/chromium-browser</command></action></item>
+<item label="Chromium" icon="/usr/share/icons/hicolor/48x48/apps/chromium.png"><action name="Execute"><command>/usr/bin/wrapped-chromium</command></action></item>
 </menu>
 </openbox_menu>

--- a/root/usr/bin/wrapped-chromium
+++ b/root/usr/bin/wrapped-chromium
@@ -3,7 +3,9 @@
 BIN=/usr/bin/chromium
 
 # Cleanup
-rm -f $HOME/.config/chromium/Singleton*
+if ! pgrep chromium > /dev/null;then
+  rm -f $HOME/.config/chromium/Singleton*
+fi
 
 # Run normally on privved containers or modified un non priv
 if grep -q 'Seccomp:\t0' /proc/1/status; then

--- a/root/usr/bin/wrapped-chromium
+++ b/root/usr/bin/wrapped-chromium
@@ -2,6 +2,9 @@
 
 BIN=/usr/bin/chromium
 
+# Cleanup
+rm -f $HOME/.config/chromium/Singleton*
+
 # Run normally on privved containers or modified un non priv
 if grep -q 'Seccomp:\t0' /proc/1/status; then
   ${BIN} \


### PR DESCRIPTION
From #19 chromium has these singleton locks that do not get cleaned up when the container exits I purge them if chromium is not running when launched. 