### PR TITLE
remove bad launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.25:** - Update chromium launch options to improve performance.
 * **10.02.24:** - Update Readme with new env vars and ingest proper PWA icon.
 * **08.01.24:** - Fix re-launch issue for chromium by purging temp files on launch.
 * **29.12.23:** - Rebase to Debian Bookworm.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -109,6 +109,7 @@ init_diagram: |
   "chromium:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.25:", desc: "Update chromium launch options to improve performance."}
   - {date: "10.02.24:", desc: "Update Readme with new env vars and ingest proper PWA icon."}
   - {date: "08.01.24:", desc: "Fix re-launch issue for chromium by purging temp files on launch."}
   - {date: "29.12.23:", desc: "Rebase to Debian Bookworm."}

--- a/root/usr/bin/wrapped-chromium
+++ b/root/usr/bin/wrapped-chromium
@@ -10,7 +10,6 @@ fi
 # Run normally on privved containers or modified un non priv
 if grep -q 'Seccomp:.0' /proc/1/status; then
   ${BIN} \
-  --ignore-gpu-blocklist \
   --no-first-run \
   --password-store=basic \
   --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT' \
@@ -19,7 +18,6 @@ if grep -q 'Seccomp:.0' /proc/1/status; then
    "$@" > /dev/null 2>&1
 else
   ${BIN} \
-  --ignore-gpu-blocklist \
   --no-first-run \
   --no-sandbox \
   --password-store=basic \


### PR DESCRIPTION
This flag has a huge impact on performance, when set chromium uses a CPU to paint the pixels in the window for everything. Seems to handle much better without it. 