### PR TITLE
add wayland init logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.
 * **01.07.25:** - Add Kasm branch.
 * **24.06.25:** - Rebase to Selkies.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -114,6 +114,7 @@ init_diagram: |
   "chromium:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}
   - {date: "01.07.25:", desc: "Add Kasm branch."}
   - {date: "24.06.25:", desc: "Rebase to Selkies."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,0 +1,2 @@
+#!/bin/bash
+wrapped-chromium --enable-features=UseOzonePlatform --ozone-platform=wayland ${CHROME_CLI}

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openbox_menu xmlns="http://openbox.org/3.4/menu">
+<menu id="root-menu" label="MENU">
+<item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
+<item label="Chromium" icon="/usr/share/icons/hicolor/48x48/apps/chromium.png"><action name="Execute"><command>/usr/bin/wrapped-chromium --enable-features=UseOzonePlatform --ozone-platform=wayland</command></action></item>
+</menu>
+</openbox_menu>


### PR DESCRIPTION
These are the needed files for wayland mode to function properly. In general openbox and labwc format is compatible so this is not strictly needed but stuff like using foot instead of xterm and app by app variables needed for native wayland support vs xwayland it is better to have them in their own files. 

This can be tested with: 
```
docker run --rm -it --shm-size=1gb -p 3001:3001 -e PIXELFLUX_WAYLAND=true lsiodev/chromium bash
```

Zero copy AMD/Intel:
```
docker run --rm -it --shm-size=1gb -p 3001:3001 -e PIXELFLUX_WAYLAND=true --device /dev/dri:/dev/dri lsiodev/chromium bash
```

Zero copy Nvidia: 
```
docker run --rm -it --shm-size=1gb -p 3001:3001 -e PIXELFLUX_WAYLAND=true --runtime nvidia --gpus all  lsiodev/chromium  bash
```

Labwc always shows the decorations on launch, down the line this can be disabled at the DE level but you can right click the bar and disable use system title bars. 

Known wayland issues: 

1. wl-copy and paste is slow and clipboard operations are sync right now (pending next release) so when refocusing into the tab you have to click a couple times before it responds to actions. 
2. The cursor rendering is a placeholder for now as I cannot reliably get the cursor off of smithay
3. Resizing the window with a fullscreen high motion thing running in nvidia zero copy can make the chromium window go black, the session is alive and it can be closed and re-opened. This does not occur on intel or amd in my testing. 
4. Changing video setting without firing a resize can cause clipping until another resize event. 


This massively increases performance on systems with a GPU and sees a good uptick without one as well due to the nature of the new rendering pipelines, controlling the framebuffer, and being able to manage a dmabuf on an egl device. This translates to native performance as the screen is being rendered exactly like it would if it was plugged into a monitor and the encoding occurs on the card in a minimal memory copy manner. It also means we are not using an unknown path for 3d acceleration under Linux this works just like a real desktop despite it being a virtual framebuffer. So no hacks for zink support or patching of a software framebuffer. 

For example here is an [N97](https://www.cpubenchmark.net/cpu.php?cpu=Intel+N97&id=5337) running at 80 fps 1080p: 

https://github.com/user-attachments/assets/9046bcf6-cfe8-4ecd-95e6-1979fec939fa


